### PR TITLE
Improve startup error reporting for systemd usage

### DIFF
--- a/chicha-http-proxy.go
+++ b/chicha-http-proxy.go
@@ -106,6 +106,15 @@ func proxyHandler(targetURL string) http.HandlerFunc {
 	}
 }
 
+// exitWithError reports blocking failures to STDOUT and through the logger before stopping the process.
+// This keeps systemd users informed when filesystem preparation fails early in the startup path.
+func exitWithError(context string, err error) {
+	message := fmt.Sprintf("%s: %v", context, err)
+	fmt.Println(message)
+	log.Println(message)
+	os.Exit(1)
+}
+
 func main() {
 	// Color palette keeps help output readable on both dark and light backgrounds.
 	const (
@@ -150,6 +159,9 @@ func main() {
 	domain := flag.String("domain", "", "Domain for automatic Let's Encrypt certificate. Forces HTTP port to 80 and admin rights, HTTPS can be changed.")
 	showVersion := flag.Bool("version", false, "Show program version")
 
+	// Send log output to STDOUT so systemd captures it consistently.
+	log.SetOutput(os.Stdout)
+
 	// Parse the flags
 	flag.Parse()
 
@@ -180,8 +192,8 @@ func main() {
 	// Create the proxy handler
 	handler := proxyHandler(*targetURL)
 
-	// 'done' channel is used to keep the main goroutine running.
-	done := make(chan bool)
+	// errorChan collects startup/runtime issues from goroutines so we can surface them to systemd.
+	errorChan := make(chan error)
 
 	// Start HTTP server. If a domain is given, this will always be on port 80.
 	// If no domain is given, this uses the user-specified port.
@@ -193,7 +205,7 @@ func main() {
 			}
 			log.Printf("Starting HTTP proxy on port %s targeting %s", *httpPort, *targetURL)
 			if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				log.Fatalf("HTTP server error: %v", err)
+				errorChan <- fmt.Errorf("HTTP server error: %w", err)
 			}
 		}()
 	}
@@ -203,13 +215,13 @@ func main() {
 		// Obtain the user's home directory to store certificates.
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			log.Fatalf("Failed to get user home directory: %v", err)
+			exitWithError("Failed to get user home directory", err)
 		}
 
 		// Setup the directory to store TLS certificates.
 		certDir := filepath.Join(homeDir, ".chicha-http-proxy-ssl-certs")
 		if err := os.MkdirAll(certDir, 0700); err != nil {
-			log.Fatalf("Failed to create cert directory: %v", err)
+			exitWithError("Failed to create cert directory", err)
 		}
 
 		go func() {
@@ -227,11 +239,15 @@ func main() {
 
 			log.Printf("Starting HTTPS proxy on domain %s and port %s targeting %s", *domain, *httpsPort, *targetURL)
 			if err := httpsServer.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
-				log.Fatalf("HTTPS server error: %v", err)
+				errorChan <- fmt.Errorf("HTTPS server error: %w", err)
 			}
 		}()
 	}
 
-	// Block until something signals the 'done' channel.
-	<-done
+	// Block until a goroutine reports an unrecoverable error so we can show it directly.
+	if err := <-errorChan; err != nil {
+		fmt.Printf("Fatal error: %v\n", err)
+		log.Printf("Fatal error: %v", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
## Summary
- add a helper that reports fatal setup errors directly to stdout before exiting
- forward HTTP and HTTPS server failures through a shared error channel for clearer systemd logs
- route default logger output to stdout so early failures are visible under systemd

## Testing
- go build ./... *(fails: missing go.sum entry for golang.org/x/crypto/acme/autocert)*

------
https://chatgpt.com/codex/tasks/task_e_68ff5d038df08332a2d4f12a4952b3cd