### PR TITLE
Add Linux --setup wizard, service generation, and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+# This workflow publishes cross-compiled binaries when a commit message includes "stable release".
+name: release
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  build:
+    # We gate releases on the commit message so routine pushes do not publish artifacts.
+    if: contains(github.event.head_commit.message, 'stable release')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            ext: ""
+          - goos: linux
+            goarch: arm64
+            ext: ""
+          - goos: darwin
+            goarch: amd64
+            ext: ""
+          - goos: darwin
+            goarch: arm64
+            ext: ""
+          - goos: windows
+            goarch: amd64
+            ext: ".exe"
+          - goos: windows
+            goarch: arm64
+            ext: ".exe"
+          - goos: freebsd
+            goarch: amd64
+            ext: ""
+          - goos: freebsd
+            goarch: arm64
+            ext: ""
+          - goos: openbsd
+            goarch: amd64
+            ext: ""
+          - goos: openbsd
+            goarch: arm64
+            ext: ""
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          # We build with trimpath and a version string to keep artifacts deterministic.
+          mkdir -p dist
+          output="dist/chicha-http-proxy-${GOOS}-${GOARCH}${{ matrix.ext }}"
+          go build -trimpath -ldflags "-s -w -X main.version=${{ github.sha }}" -o "${output}" .
+          tar -czf "${output}.tar.gz" -C dist "$(basename "${output}")"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: chicha-http-proxy-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*.tar.gz
+
+  release:
+    # Release waits for all builds so the GitHub release has a full set of artifacts.
+    if: contains(github.event.head_commit.message, 'stable release')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: stable-${{ github.run_number }}
+          name: Stable release ${{ github.run_number }}
+          files: dist/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/chicha-http-proxy.go
+++ b/chicha-http-proxy.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+
+	"chicha-proxy/pkg/setup"
 )
 
 // Program version (will be printed if the --version flag is used)
@@ -212,6 +214,7 @@ func main() {
 	domain := flag.String("domain", "", "Domain for automatic Let's Encrypt certificate. Forces HTTP port to 80 and admin rights, HTTPS can be changed.")
 	hostModeFlag := flag.String("host-mode", "domain", "Controls which host is forwarded upstream: 'domain' keeps the public name, 'target' preserves the backend host.")
 	showVersion := flag.Bool("version", false, "Show program version")
+	setupFlag := setup.RegisterFlag()
 
 	// Send log output to STDOUT so systemd captures it consistently.
 	log.SetOutput(os.Stdout)
@@ -223,6 +226,14 @@ func main() {
 	if *showVersion {
 		fmt.Printf("Program version: %s\n", version)
 		os.Exit(0)
+	}
+
+	// --setup runs the Linux-only interactive installation and then exits cleanly.
+	if setupFlag != nil && *setupFlag {
+		if err := setup.RunInteractive(); err != nil {
+			exitWithError("Setup failed", err)
+		}
+		return
 	}
 
 	// The target URL must be specified.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,7 @@
+<!-- This document explains the Linux-only setup flow for operators. -->
+
+# Linux interactive setup
+
+The `--setup` flag is available only on Linux builds. It runs an interactive wizard that asks whether to enable HTTPS, which domain to secure, and which upstream URL should receive forwarded requests.
+
+After answering the prompts, the setup script checks whether the host uses `systemd` or legacy `init.d` and writes the appropriate service definition. It also appends operational commands to `/etc/info` so operators can start, stop, and view logs quickly.

--- a/pkg/setup/setup_linux.go
+++ b/pkg/setup/setup_linux.go
@@ -1,0 +1,419 @@
+//go:build linux
+
+package setup
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ----- Flag registration -----
+
+// RegisterFlag is split by build tags so non-Linux builds avoid exposing the setup flag.
+func RegisterFlag() *bool {
+	return flag.Bool("setup", false, "Run interactive service setup for Linux hosts.")
+}
+
+// ----- Interactive setup flow -----
+
+// initSystem identifies which init system we should generate service files for.
+type initSystem string
+
+const (
+	initSystemd initSystem = "systemd"
+	initInitd   initSystem = "initd"
+)
+
+// setupAnswers groups prompt output so the main setup flow stays readable.
+type setupAnswers struct {
+	useHTTPS bool
+	domain   string
+	target   string
+}
+
+// RunInteractive gathers setup details, installs the service, and writes runbook details to /etc/info.
+func RunInteractive() error {
+	answersCh := make(chan setupAnswers, 1)
+	promptErrCh := make(chan error, 1)
+	initCh := make(chan initDetectResult, 1)
+
+	go func() {
+		answers, err := promptAnswers()
+		if err != nil {
+			promptErrCh <- err
+			return
+		}
+		answersCh <- answers
+	}()
+
+	go func() {
+		initCh <- detectInitSystem()
+	}()
+
+	var answers setupAnswers
+	select {
+	case err := <-promptErrCh:
+		return err
+	case answers = <-answersCh:
+	}
+
+	initResult := <-initCh
+	if initResult.err != nil {
+		return initResult.err
+	}
+
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve binary path: %w", err)
+	}
+
+	binaryPath, err = filepath.Abs(binaryPath)
+	if err != nil {
+		return fmt.Errorf("normalize binary path: %w", err)
+	}
+
+	serviceConfig := buildServiceConfig(binaryPath, answers)
+	if err := writeServiceFiles(initResult.system, serviceConfig); err != nil {
+		return err
+	}
+
+	if err := appendInfo(initResult.system, serviceConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ----- Prompt helpers -----
+
+// promptAnswers coordinates input prompts so the caller can keep orchestration minimal.
+func promptAnswers() (setupAnswers, error) {
+	reader := bufio.NewReader(os.Stdin)
+	useHTTPS, err := promptYesNo(reader, "Use HTTPS for the public endpoint? (y/n): ")
+	if err != nil {
+		return setupAnswers{}, err
+	}
+
+	domain := ""
+	if useHTTPS {
+		domain, err = promptNonEmpty(reader, "Enter the domain to secure with Let's Encrypt: ")
+		if err != nil {
+			return setupAnswers{}, err
+		}
+	}
+
+	target, err := promptNonEmpty(reader, "Where should requests be forwarded? (example: https://backend.local): ")
+	if err != nil {
+		return setupAnswers{}, err
+	}
+
+	parsedTarget, err := url.Parse(target)
+	if err != nil {
+		return setupAnswers{}, fmt.Errorf("target URL parse failed: %w", err)
+	}
+	if parsedTarget.Scheme == "" || parsedTarget.Host == "" {
+		return setupAnswers{}, errors.New("target URL must include scheme and host")
+	}
+
+	return setupAnswers{useHTTPS: useHTTPS, domain: domain, target: target}, nil
+}
+
+// promptYesNo asks for a yes/no answer and keeps prompting until valid input arrives.
+func promptYesNo(reader *bufio.Reader, prompt string) (bool, error) {
+	for {
+		fmt.Print(prompt)
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return false, fmt.Errorf("read answer: %w", err)
+		}
+		answer = strings.TrimSpace(strings.ToLower(answer))
+		switch answer {
+		case "y", "yes":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		default:
+			fmt.Println("Please answer with y or n.")
+		}
+	}
+}
+
+// promptNonEmpty ensures we do not accept blank answers for required values.
+func promptNonEmpty(reader *bufio.Reader, prompt string) (string, error) {
+	for {
+		fmt.Print(prompt)
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return "", fmt.Errorf("read answer: %w", err)
+		}
+		answer = strings.TrimSpace(answer)
+		if answer != "" {
+			return answer, nil
+		}
+		fmt.Println("Value cannot be empty.")
+	}
+}
+
+// ----- Init system detection -----
+
+// initDetectResult bundles init detection output for channel use.
+type initDetectResult struct {
+	system initSystem
+	err    error
+}
+
+// detectInitSystem inspects common Linux locations to determine the active init system.
+func detectInitSystem() initDetectResult {
+	if isSystemdAvailable() {
+		return initDetectResult{system: initSystemd}
+	}
+	if isInitdAvailable() {
+		return initDetectResult{system: initInitd}
+	}
+	return initDetectResult{err: errors.New("unable to detect systemd or init.d")}
+}
+
+// isSystemdAvailable checks for systemd runtime markers instead of executing systemctl.
+func isSystemdAvailable() bool {
+	if _, err := os.Stat("/run/systemd/system"); err == nil {
+		return true
+	}
+	if _, err := os.Stat("/bin/systemctl"); err == nil {
+		return true
+	}
+	if _, err := os.Stat("/usr/bin/systemctl"); err == nil {
+		return true
+	}
+	return false
+}
+
+// isInitdAvailable checks for legacy init scripts so we can fallback when systemd is absent.
+func isInitdAvailable() bool {
+	if _, err := os.Stat("/etc/init.d"); err == nil {
+		return true
+	}
+	return false
+}
+
+// ----- Service rendering -----
+
+// serviceConfig centralizes install paths so we can render multiple outputs consistently.
+type serviceConfig struct {
+	binaryPath  string
+	useHTTPS    bool
+	domain      string
+	targetURL   string
+	logFilePath string
+}
+
+// buildServiceConfig normalizes values and keeps future changes localized.
+func buildServiceConfig(binaryPath string, answers setupAnswers) serviceConfig {
+	return serviceConfig{
+		binaryPath:  binaryPath,
+		useHTTPS:    answers.useHTTPS,
+		domain:      answers.domain,
+		targetURL:   answers.target,
+		logFilePath: "/var/log/chicha-http-proxy.log",
+	}
+}
+
+// writeServiceFiles writes either systemd or init.d artifacts depending on detection.
+func writeServiceFiles(system initSystem, cfg serviceConfig) error {
+	switch system {
+	case initSystemd:
+		return writeSystemd(cfg)
+	case initInitd:
+		return writeInitd(cfg)
+	default:
+		return fmt.Errorf("unsupported init system: %s", system)
+	}
+}
+
+// writeSystemd writes the unit file and reloads systemd so the service is discoverable.
+func writeSystemd(cfg serviceConfig) error {
+	unitPath := "/etc/systemd/system/chicha-http-proxy.service"
+	unitContent := renderSystemdUnit(cfg)
+	if err := os.WriteFile(unitPath, []byte(unitContent), 0644); err != nil {
+		return fmt.Errorf("write systemd unit: %w", err)
+	}
+
+	cmd := exec.Command("systemctl", "daemon-reload")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("systemctl daemon-reload failed: %w", err)
+	}
+
+	return nil
+}
+
+// renderSystemdUnit generates the systemd unit contents using the resolved binary path.
+func renderSystemdUnit(cfg serviceConfig) string {
+	execLine := fmt.Sprintf("%s --target-url %s", cfg.binaryPath, cfg.targetURL)
+	if cfg.useHTTPS {
+		execLine = fmt.Sprintf("%s --domain %s", execLine, cfg.domain)
+	}
+
+	return fmt.Sprintf(`[Unit]
+Description=Chicha HTTP Proxy
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=%s
+Restart=on-failure
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+`, execLine)
+}
+
+// writeInitd writes a SysV init script and marks it executable.
+func writeInitd(cfg serviceConfig) error {
+	initPath := "/etc/init.d/chicha-http-proxy"
+	content := renderInitdScript(cfg)
+	if err := os.WriteFile(initPath, []byte(content), 0755); err != nil {
+		return fmt.Errorf("write init.d script: %w", err)
+	}
+	return nil
+}
+
+// renderInitdScript returns a basic init script with pidfile and log redirection.
+func renderInitdScript(cfg serviceConfig) string {
+	execLine := fmt.Sprintf("%s --target-url %s", cfg.binaryPath, cfg.targetURL)
+	if cfg.useHTTPS {
+		execLine = fmt.Sprintf("%s --domain %s", execLine, cfg.domain)
+	}
+
+	return fmt.Sprintf(`#!/bin/sh
+#
+# /etc/init.d/chicha-http-proxy
+#
+### BEGIN INIT INFO
+# Provides:          chicha-http-proxy
+# Required-Start:    $network
+# Required-Stop:     $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Chicha HTTP Proxy
+### END INIT INFO
+
+DAEMON="%s"
+DAEMON_ARGS="%s"
+PIDFILE="/var/run/chicha-http-proxy.pid"
+LOGFILE="%s"
+
+start() {
+	printf "Starting chicha-http-proxy...\n"
+	if [ -f "$PIDFILE" ]; then
+		printf "Already running.\n"
+		return 1
+	fi
+	nohup $DAEMON $DAEMON_ARGS >> "$LOGFILE" 2>&1 &
+	echo $! > "$PIDFILE"
+	printf "Started.\n"
+}
+
+stop() {
+	printf "Stopping chicha-http-proxy...\n"
+	if [ ! -f "$PIDFILE" ]; then
+		printf "Not running.\n"
+		return 1
+	fi
+	kill "$(cat "$PIDFILE")"
+	rm -f "$PIDFILE"
+	printf "Stopped.\n"
+}
+
+status() {
+	if [ -f "$PIDFILE" ]; then
+		printf "Running (PID $(cat "$PIDFILE")).\n"
+	else
+		printf "Stopped.\n"
+	fi
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	status)
+		status
+		;;
+	restart)
+		stop
+		start
+		;;
+	*)
+		echo "Usage: $0 {start|stop|status|restart}"
+		exit 1
+		;;
+esac
+
+exit 0
+`, cfg.binaryPath, execLine, cfg.logFilePath)
+}
+
+// ----- /etc/info updates -----
+
+// appendInfo adds a runbook section to /etc/info with commands tailored to the init system.
+func appendInfo(system initSystem, cfg serviceConfig) error {
+	infoPath := "/etc/info"
+	now := time.Now().Format(time.RFC3339)
+	content := renderInfo(system, cfg, now)
+
+	file, err := os.OpenFile(infoPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open /etc/info: %w", err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(content); err != nil {
+		return fmt.Errorf("write /etc/info: %w", err)
+	}
+	return nil
+}
+
+// renderInfo writes a timestamped block so operators can discover service usage quickly.
+func renderInfo(system initSystem, cfg serviceConfig, timestamp string) string {
+	var builder strings.Builder
+	builder.WriteString("\n")
+	builder.WriteString("Chicha HTTP Proxy setup (generated at " + timestamp + ")\n")
+	builder.WriteString("Target URL: " + cfg.targetURL + "\n")
+	if cfg.useHTTPS {
+		builder.WriteString("HTTPS domain: " + cfg.domain + "\n")
+	} else {
+		builder.WriteString("HTTPS disabled for this setup.\n")
+	}
+	builder.WriteString("Binary path: " + cfg.binaryPath + "\n")
+
+	switch system {
+	case initSystemd:
+		builder.WriteString("Start: systemctl start chicha-http-proxy\n")
+		builder.WriteString("Stop: systemctl stop chicha-http-proxy\n")
+		builder.WriteString("Status: systemctl status chicha-http-proxy\n")
+		builder.WriteString("Logs: journalctl -u chicha-http-proxy -f\n")
+	case initInitd:
+		builder.WriteString("Start: service chicha-http-proxy start\n")
+		builder.WriteString("Stop: service chicha-http-proxy stop\n")
+		builder.WriteString("Status: service chicha-http-proxy status\n")
+		builder.WriteString("Logs: tail -f " + cfg.logFilePath + "\n")
+	default:
+		builder.WriteString("Unknown init system detected; manual startup required.\n")
+	}
+
+	return builder.String()
+}

--- a/pkg/setup/setup_linux.go
+++ b/pkg/setup/setup_linux.go
@@ -15,6 +15,16 @@ import (
 	"time"
 )
 
+// ----- Console styling -----
+
+const (
+	colorReset       = "\033[0m"
+	colorTitle       = "\033[38;5;45m"
+	colorSection     = "\033[38;5;33m"
+	colorHighlight   = "\033[38;5;214m"
+	colorDescription = "\033[38;5;244m"
+)
+
 // ----- Flag registration -----
 
 // RegisterFlag is split by build tags so non-Linux builds avoid exposing the setup flag.
@@ -41,6 +51,8 @@ type setupAnswers struct {
 
 // RunInteractive gathers setup details, installs the service, and writes runbook details to /etc/info.
 func RunInteractive() error {
+	printBanner()
+
 	answersCh := make(chan setupAnswers, 1)
 	promptErrCh := make(chan error, 1)
 	initCh := make(chan initDetectResult, 1)
@@ -69,6 +81,7 @@ func RunInteractive() error {
 	if initResult.err != nil {
 		return initResult.err
 	}
+	printDetectedInit(initResult.system)
 
 	binaryPath, err := os.Executable()
 	if err != nil {
@@ -81,15 +94,26 @@ func RunInteractive() error {
 	}
 
 	serviceConfig := buildServiceConfig(binaryPath, answers)
-	if err := writeServiceFiles(initResult.system, serviceConfig); err != nil {
+	serviceErr := writeServiceFiles(initResult.system, serviceConfig)
+	printServiceSummary(initResult.system, serviceConfig)
+
+	infoContent := renderInfo(initResult.system, serviceConfig, time.Now().Format(time.RFC3339))
+	if err := appendInfo(infoContent); err != nil {
 		return err
 	}
+	printInfoAppend(infoContent)
 
-	if err := appendInfo(initResult.system, serviceConfig); err != nil {
-		return err
+	if serviceErr != nil {
+		printCommandResult(commandResult{command: "service install", output: "", err: serviceErr})
 	}
 
-	return nil
+	startResult := attemptStartService(initResult.system)
+	printStartResult(startResult)
+
+	logsResult := attemptTailLogs(initResult.system, serviceConfig)
+	printLogsResult(logsResult)
+
+	return serviceErr
 }
 
 // ----- Prompt helpers -----
@@ -97,20 +121,21 @@ func RunInteractive() error {
 // promptAnswers coordinates input prompts so the caller can keep orchestration minimal.
 func promptAnswers() (setupAnswers, error) {
 	reader := bufio.NewReader(os.Stdin)
-	useHTTPS, err := promptYesNo(reader, "Use HTTPS for the public endpoint? (y/n): ")
+	useHTTPS, err := promptYesNo(reader, fmt.Sprintf("%sUse HTTPS for the public endpoint? (y/n): %s", colorSection, colorReset))
 	if err != nil {
 		return setupAnswers{}, err
 	}
 
 	domain := ""
 	if useHTTPS {
-		domain, err = promptNonEmpty(reader, "Enter the domain to secure with Let's Encrypt: ")
+		domain, err = promptNonEmpty(reader, fmt.Sprintf("%sEnter the domain to secure with Let's Encrypt: %s", colorSection, colorReset))
 		if err != nil {
 			return setupAnswers{}, err
 		}
 	}
 
-	target, err := promptNonEmpty(reader, "Where should requests be forwarded? (example: https://backend.local): ")
+	defaultTarget := "http://127.0.0.1:8080"
+	target, err := promptWithDefault(reader, fmt.Sprintf("%sWhere should requests be forwarded? (default %s): %s", colorSection, defaultTarget, colorReset), defaultTarget)
 	if err != nil {
 		return setupAnswers{}, err
 	}
@@ -159,6 +184,22 @@ func promptNonEmpty(reader *bufio.Reader, prompt string) (string, error) {
 			return answer, nil
 		}
 		fmt.Println("Value cannot be empty.")
+	}
+}
+
+// promptWithDefault returns a default value when the user presses enter.
+func promptWithDefault(reader *bufio.Reader, prompt string, fallback string) (string, error) {
+	for {
+		fmt.Print(prompt)
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return "", fmt.Errorf("read answer: %w", err)
+		}
+		answer = strings.TrimSpace(answer)
+		if answer == "" {
+			return fallback, nil
+		}
+		return answer, nil
 	}
 }
 
@@ -370,10 +411,8 @@ exit 0
 // ----- /etc/info updates -----
 
 // appendInfo adds a runbook section to /etc/info with commands tailored to the init system.
-func appendInfo(system initSystem, cfg serviceConfig) error {
+func appendInfo(content string) error {
 	infoPath := "/etc/info"
-	now := time.Now().Format(time.RFC3339)
-	content := renderInfo(system, cfg, now)
 
 	file, err := os.OpenFile(infoPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -416,4 +455,113 @@ func renderInfo(system initSystem, cfg serviceConfig, timestamp string) string {
 	}
 
 	return builder.String()
+}
+
+// ----- Operator feedback -----
+
+// printBanner introduces the setup with a friendly header.
+func printBanner() {
+	fmt.Printf("%sChicha HTTP Proxy Setup%s\n", colorTitle, colorReset)
+	fmt.Printf("%sInteractive Linux installer%s\n\n", colorDescription, colorReset)
+}
+
+// printDetectedInit highlights the init system so operators know what was chosen.
+func printDetectedInit(system initSystem) {
+	fmt.Printf("%sDetected init system:%s %s\n", colorSection, colorReset, system)
+}
+
+// printServiceSummary shows the generated service command line.
+func printServiceSummary(system initSystem, cfg serviceConfig) {
+	execLine := fmt.Sprintf("%s --target-url %s", cfg.binaryPath, cfg.targetURL)
+	if cfg.useHTTPS {
+		execLine = fmt.Sprintf("%s --domain %s", execLine, cfg.domain)
+	}
+	fmt.Printf("%sService command:%s %s\n", colorSection, colorReset, execLine)
+	fmt.Printf("%sService type:%s %s\n\n", colorSection, colorReset, system)
+}
+
+// printInfoAppend confirms the content added to /etc/info.
+func printInfoAppend(content string) {
+	fmt.Printf("%sAppended to /etc/info:%s\n%s\n", colorSection, colorReset, content)
+}
+
+// ----- Service start and logs -----
+
+// commandResult captures command execution so we can report to the operator.
+type commandResult struct {
+	command string
+	output  string
+	err     error
+}
+
+// attemptStartService tries to start the service and collect status output.
+func attemptStartService(system initSystem) []commandResult {
+	results := []commandResult{}
+
+	switch system {
+	case initSystemd:
+		results = append(results, runCommand("systemctl", "enable", "--now", "chicha-http-proxy"))
+		results = append(results, runCommand("systemctl", "status", "chicha-http-proxy", "--no-pager"))
+	case initInitd:
+		results = append(results, runCommand("service", "chicha-http-proxy", "start"))
+		results = append(results, runCommand("service", "chicha-http-proxy", "status"))
+	default:
+		results = append(results, commandResult{command: "init system unknown", output: "", err: errors.New("unsupported init system")})
+	}
+
+	return results
+}
+
+// attemptTailLogs fetches recent logs so operators see immediate output.
+func attemptTailLogs(system initSystem, cfg serviceConfig) []commandResult {
+	results := []commandResult{}
+
+	switch system {
+	case initSystemd:
+		results = append(results, runCommand("journalctl", "-u", "chicha-http-proxy", "-n", "50", "--no-pager"))
+	case initInitd:
+		results = append(results, runCommand("tail", "-n", "50", cfg.logFilePath))
+	default:
+		results = append(results, commandResult{command: "log system unknown", output: "", err: errors.New("unsupported init system")})
+	}
+
+	return results
+}
+
+// runCommand executes a command and captures combined output for display.
+func runCommand(name string, args ...string) commandResult {
+	cmd := exec.Command(name, args...)
+	output, err := cmd.CombinedOutput()
+	return commandResult{command: strings.Join(append([]string{name}, args...), " "), output: string(output), err: err}
+}
+
+// printStartResult renders service start and status output to the console.
+func printStartResult(results []commandResult) {
+	fmt.Printf("%sService startup attempts:%s\n", colorSection, colorReset)
+	for _, result := range results {
+		printCommandResult(result)
+	}
+}
+
+// printLogsResult renders log output for immediate troubleshooting.
+func printLogsResult(results []commandResult) {
+	fmt.Printf("%sService logs:%s\n", colorSection, colorReset)
+	for _, result := range results {
+		printCommandResult(result)
+	}
+}
+
+// printCommandResult formats a single command output block.
+func printCommandResult(result commandResult) {
+	status := "ok"
+	if result.err != nil {
+		status = "failed"
+	}
+	fmt.Printf("%s> %s%s (%s)%s\n", colorHighlight, result.command, colorReset, status, colorReset)
+	if result.output != "" {
+		fmt.Println(result.output)
+	}
+	if result.err != nil {
+		fmt.Printf("%sError:%s %v\n", colorHighlight, colorReset, result.err)
+	}
 }

--- a/pkg/setup/setup_stub.go
+++ b/pkg/setup/setup_stub.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package setup
+
+// RegisterFlag is a no-op on non-Linux platforms so the setup flag stays Linux-only.
+func RegisterFlag() *bool {
+	return nil
+}
+
+// RunInteractive is intentionally unavailable on non-Linux platforms.
+func RunInteractive() error {
+	return nil
+}


### PR DESCRIPTION
### Motivation

- Provide a simple interactive installer for Linux hosts to configure the proxy (ask whether to use HTTPS, which domain, and where to forward requests).
- Make it easy to install and run the proxy as a service by auto-generating either `systemd` unit files or a SysV `init.d` script depending on the host.
- Improve operator discovery by writing runbook/service commands to `/etc/info` and provide a documented workflow.

### Description

- Added a Linux-only `pkg/setup` package (build-tagged) exposing `RegisterFlag()` and `RunInteractive()` which implements an interactive setup that prompts for HTTPS usage, domain, and target URL and validates the target URL with `url.Parse`.
- The setup flow detects the init system with `detectInitSystem()` and writes either a `systemd` unit at `/etc/systemd/system/chicha-http-proxy.service` or an init.d script at `/etc/init.d/chicha-http-proxy`, and appends a timestamped runbook block to `/etc/info` with start/stop/status/log commands.
- Wired the CLI to register the Linux-only `--setup` flag and invoke `setup.RunInteractive()` early in `main` (in `chicha-http-proxy.go`) so invocation `--setup` runs the interactive installer and exits.
- Added a non-Linux stub `pkg/setup/setup_stub.go` so the `--setup` flag is not exposed on other platforms, and added `docs/setup.md` describing the flow.
- Added a GitHub Actions workflow at `.github/workflows/release.yml` to produce cross-platform artifacts when a commit message contains `stable release`.

### Testing

- Ran `go test ./...` which completed successfully (packages report no test files and no failures).
- Ensured formatting with `gofmt -w` on modified files and ran `go mod tidy` to refresh module metadata (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b1a396e48833297f3466e02ee6689)